### PR TITLE
Disasbled attempted generation of non-VS .NET Core projects

### DIFF
--- a/Coral.Managed/premake5.lua
+++ b/Coral.Managed/premake5.lua
@@ -1,24 +1,28 @@
 include "../Premake/CSExtensions.lua"
 
 project "Coral.Managed"
-    language "C#"
-    dotnetframework "net8.0"
-    kind "SharedLib"
-	clr "Unsafe"
-	targetdir("Build/%{cfg.buildcfg}-%{cfg.system}")
-	objdir("Intermediates/%{cfg.buildcfg}-%{cfg.system}")
+    filter { "not action:vs*", "not system:windows" }
+        kind "StaticLib"
+    filter { "action:vs* or system:windows" }
+        language "C#"
+        dotnetframework "net8.0"
+        kind "SharedLib"
+        clr "Unsafe"
+        targetdir("../Build/%{cfg.buildcfg}")
+        objdir("../Intermediates/%{cfg.buildcfg}")
+        dependson { "Coral.Generator" }
 
-    -- Don't specify architecture here. (see https://github.com/premake/premake-core/issues/1758)
+        -- Don't specify architecture here. (see https://github.com/premake/premake-core/issues/1758)
 
-    propertytags {
-        { "AppendTargetFrameworkToOutputPath", "false" },
-        { "Nullable", "enable" },
-    }
+        propertytags {
+            { "AppendTargetFrameworkToOutputPath", "false" },
+            { "Nullable", "enable" },
+        }
 
-    disablewarnings {
-        "CS8500"
-    }
+        disablewarnings {
+            "CS8500"
+        }
 
-    files {
-        "Source/**.cs"
-    }
+        files {
+            "Source/**.cs"
+        }


### PR DESCRIPTION
Only VS SLN actions can produce potable .NET Core builds under premake -- made ``Coral.Managed`` reject other configurations by blanking out the target as an empty static lib.