### PR TITLE
Change from `==` to `Equals` in string compare

### DIFF
--- a/Coral.Managed/Source/InternalCalls.cs
+++ b/Coral.Managed/Source/InternalCalls.cs
@@ -50,7 +50,7 @@ internal static class InternalCallsManager
 				}
 
 				var bindingFlags = BindingFlags.Static | BindingFlags.NonPublic;
-				var field = type.GetFields(bindingFlags).FirstOrDefault(field => field.Name == fieldName);
+				var field = type.GetFields(bindingFlags).FirstOrDefault(field => field.Name.Equals(fieldName));
 
 				if (field == null)
 				{


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved string comparison for field names to enhance reliability and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->