### PR TITLE
Fix build errors related to templating on GCC

### DIFF
--- a/Coral.Native/Include/Coral/Attribute.hpp
+++ b/Coral.Native/Include/Coral/Attribute.hpp
@@ -20,22 +20,6 @@ namespace Coral {
 			return result;
 		}
 
-		template<>
-		std::string GetFieldValue(std::string_view InFieldName)
-		{
-			String result;
-			GetFieldValueInternal(InFieldName, &result);
-			return std::string(result);
-		}
-
-		template<>
-		bool GetFieldValue(std::string_view InFieldName)
-		{
-			Bool32 result;
-			GetFieldValueInternal(InFieldName, &result);
-			return result;
-		}
-
 	private:
 		void GetFieldValueInternal(std::string_view InFieldName, void* OutValue) const;
 
@@ -48,5 +32,21 @@ namespace Coral {
 		friend class FieldInfo;
 		friend class PropertyInfo;
 	};
+
+	template<>
+	inline std::string Attribute::GetFieldValue<std::string>(std::string_view InFieldName)
+	{
+		String result;
+		GetFieldValueInternal(InFieldName, &result);
+		return std::string(result);
+	}
+
+	template<>
+	inline bool Attribute::GetFieldValue<bool>(std::string_view InFieldName)
+	{
+		Bool32 result;
+		GetFieldValueInternal(InFieldName, &result);
+		return result;
+	}
 
 }

--- a/Coral.Native/Include/Coral/ManagedObject.hpp
+++ b/Coral.Native/Include/Coral/ManagedObject.hpp
@@ -18,7 +18,7 @@ namespace Coral {
 			constexpr size_t parameterCount = sizeof...(InParameters);
 
 			TReturn result;
-			
+
 			if constexpr (parameterCount > 0)
 			{
 				const void* parameterValues[parameterCount];
@@ -58,43 +58,10 @@ namespace Coral {
 			SetFieldValueRaw(InFieldName, &InValue);
 		}
 
-		template<>
-		void SetFieldValue(std::string_view InFieldName, std::string InValue) const
-		{
-			String s = String::New(InValue);
-			SetFieldValueRaw(InFieldName, &InValue);
-			String::Free(s);
-		}
-
-		template<>
-		void SetFieldValue(std::string_view InFieldName, bool InValue) const
-		{
-			Bool32 s = InValue;
-			SetFieldValueRaw(InFieldName, &s);
-		}
-
 		template<typename TReturn>
 		TReturn GetFieldValue(std::string_view InFieldName) const
 		{
 			TReturn result;
-			GetFieldValueRaw(InFieldName, &result);
-			return result;
-		}
-
-		template<>
-		std::string GetFieldValue(std::string_view InFieldName) const
-		{
-			String result;
-			GetFieldValueRaw(InFieldName, &result);
-			auto s = std::string(result);
-			String::Free(result);
-			return s;
-		}
-
-		template<>
-		bool GetFieldValue(std::string_view InFieldName) const
-		{
-			Bool32 result;
 			GetFieldValueRaw(InFieldName, &result);
 			return result;
 		}
@@ -119,7 +86,7 @@ namespace Coral {
 		void GetPropertyValueRaw(std::string_view InPropertyName, void* OutValue) const;
 
 		const Type& GetType();
-		
+
 		void Destroy();
 
 		bool IsValid() const { return m_Handle != nullptr && m_Type != nullptr; }
@@ -136,6 +103,38 @@ namespace Coral {
 		friend class ManagedAssembly;
 		friend class Type;
 	};
-	
-}
 
+	template<> 
+	inline void ManagedObject::SetFieldValue<std::string>(std::string_view InFieldName, std::string InValue) const
+	{
+		String s = String::New(InValue);
+		SetFieldValueRaw(InFieldName, &InValue);
+		String::Free(s);
+	}
+
+	template<>
+	inline void ManagedObject::SetFieldValue<bool>(std::string_view InFieldName, bool InValue) const
+	{
+		Bool32 s = InValue;
+		SetFieldValueRaw(InFieldName, &s);
+	}
+
+	template<>
+	inline std::string ManagedObject::GetFieldValue<std::string>(std::string_view InFieldName) const
+	{
+		String result;
+		GetFieldValueRaw(InFieldName, &result);
+		auto s = std::string(result);
+		String::Free(result);
+		return s;
+	}
+
+	template<>
+	inline bool ManagedObject::GetFieldValue<bool>(std::string_view InFieldName) const
+	{
+		Bool32 result;
+		GetFieldValueRaw(InFieldName, &result);
+		return result;
+	}
+
+}


### PR DESCRIPTION
Today I cloned Coral onto my development Linux machine for use in a personal project. I encountered the following build errors on the latest commit of the `main` branch ([`6075e76`](https://github.com/StudioCherno/Coral/commit/6075e76d4ea81d54a37ee47edefceb191171f8a1)).

For the sake of completeness, I initially encountered this while implementing a separate CMake-based buildsystem. I verified that this also occurs on the Premake build on a clean checkout of the `main` branch. The following log is of the Premake build.

This PR fixes these build errors.

Premake version: `5.0.0-beta7`
CMake version: `3.27.0`
g++ (GCC) version: `15.2.1 20250813`

Build command:
```bash
premake5 gmake2 --file=premake5-native.lua
make -j 8
```

Build log:
```
In file included from Include/Coral/Type.hpp:5,
                 from Source/Coral/FieldInfo.cpp:2:
Include/Coral/ManagedObject.hpp:61:26: error: explicit specialization in non-namespace scope ‘class Coral::ManagedObject’
   61 |                 template<>
      |                          ^
Include/Coral/ManagedObject.hpp:69:26: error: explicit specialization in non-namespace scope ‘class Coral::ManagedObject’
   69 |                 template<>
      |                          ^
Include/Coral/ManagedObject.hpp:84:26: error: explicit specialization in non-namespace scope ‘class Coral::ManagedObject’
   84 |                 template<>
      |                          ^
Include/Coral/ManagedObject.hpp:94:26: error: explicit specialization in non-namespace scope ‘class Coral::ManagedObject’
   94 |                 template<>
      |                          ^
Include/Coral/ManagedObject.hpp:95:22: error: ‘bool Coral::ManagedObject::GetFieldValue(std::string_view) const’ cannot be overloaded with ‘std::string Coral::ManagedObject::GetFieldValue(std::string_view) const’
   95 |                 bool GetFieldValue(std::string_view InFieldName) const
      |                      ^~~~~~~~~~~~~
Include/Coral/ManagedObject.hpp:85:29: note: previous declaration ‘std::string Coral::ManagedObject::GetFieldValue(std::string_view) const’
   85 |                 std::string GetFieldValue(std::string_view InFieldName) const
      |                             ^~~~~~~~~~~~~
In file included from Include/Coral/Type.hpp:5,
                 from Include/Coral/Assembly.hpp:3,
                 from Include/Coral/HostInstance.hpp:5,
                 from Source/Coral/HostInstance.cpp:1:
Include/Coral/ManagedObject.hpp:61:26: error: explicit specialization in non-namespace scope ‘class Coral::ManagedObject’
   61 |                 template<>
      |                          ^
Include/Coral/ManagedObject.hpp:69:26: error: explicit specialization in non-namespace scope ‘class Coral::ManagedObject’
   69 |                 template<>
      |                          ^
Include/Coral/ManagedObject.hpp:84:26: error: explicit specialization in non-namespace scope ‘class Coral::ManagedObject’
   84 |                 template<>
      |                          ^
Include/Coral/ManagedObject.hpp:94:26: error: explicit specialization in non-namespace scope ‘class Coral::ManagedObject’
   94 |                 template<>
      |                          ^
Include/Coral/ManagedObject.hpp:95:22: error: ‘bool Coral::ManagedObject::GetFieldValue(std::string_view) const’ cannot be overloaded with ‘std::string Coral::ManagedObject::GetFieldValue(std::string_view) const’
   95 |                 bool GetFieldValue(std::string_view InFieldName) const
      |                      ^~~~~~~~~~~~~
Include/Coral/ManagedObject.hpp:85:29: note: previous declaration ‘std::string Coral::ManagedObject::GetFieldValue(std::string_view) const’
   85 |                 std::string GetFieldValue(std::string_view InFieldName) const
      |                             ^~~~~~~~~~~~~
In file included from Include/Coral/Type.hpp:5,
                 from Source/Coral/MethodInfo.cpp:3:
Include/Coral/ManagedObject.hpp:61:26: error: explicit specialization in non-namespace scope ‘class Coral::ManagedObject’
   61 |                 template<>
      |                          ^
Include/Coral/ManagedObject.hpp:69:26: error: explicit specialization in non-namespace scope ‘class Coral::ManagedObject’
   69 |                 template<>
      |                          ^
Include/Coral/ManagedObject.hpp:84:26: error: explicit specialization in non-namespace scope ‘class Coral::ManagedObject’
   84 |                 template<>
      |                          ^
Include/Coral/ManagedObject.hpp:94:26: error: explicit specialization in non-namespace scope ‘class Coral::ManagedObject’
   94 |                 template<>
      |                          ^
Include/Coral/ManagedObject.hpp:95:22: error: ‘bool Coral::ManagedObject::GetFieldValue(std::string_view) const’ cannot be overloaded with ‘std::string Coral::ManagedObject::GetFieldValue(std::string_view) const’
   95 |                 bool GetFieldValue(std::string_view InFieldName) const
      |                      ^~~~~~~~~~~~~
Include/Coral/ManagedObject.hpp:85:29: note: previous declaration ‘std::string Coral::ManagedObject::GetFieldValue(std::string_view) const’
   85 |                 std::string GetFieldValue(std::string_view InFieldName) const
      |                             ^~~~~~~~~~~~~
In file included from Source/Coral/FieldInfo.cpp:3:
Include/Coral/Attribute.hpp:23:26: error: explicit specialization in non-namespace scope ‘class Coral::Attribute’
   23 |                 template<>
      |                          ^
Include/Coral/Attribute.hpp:31:26: error: explicit specialization in non-namespace scope ‘class Coral::Attribute’
   31 |                 template<>
      |                          ^
Include/Coral/Attribute.hpp:32:22: error: ‘bool Coral::Attribute::GetFieldValue(std::string_view)’ cannot be overloaded with ‘std::string Coral::Attribute::GetFieldValue(std::string_view)’
   32 |                 bool GetFieldValue(std::string_view InFieldName)
      |                      ^~~~~~~~~~~~~
Include/Coral/Attribute.hpp:24:29: note: previous declaration ‘std::string Coral::Attribute::GetFieldValue(std::string_view)’
   24 |                 std::string GetFieldValue(std::string_view InFieldName)
      |                             ^~~~~~~~~~~~~
In file included from Source/Coral/MethodInfo.cpp:4:
Include/Coral/Attribute.hpp:23:26: error: explicit specialization in non-namespace scope ‘class Coral::Attribute’
   23 |                 template<>
      |                          ^
Include/Coral/Attribute.hpp:31:26: error: explicit specialization in non-namespace scope ‘class Coral::Attribute’
   31 |                 template<>
      |                          ^
Include/Coral/Attribute.hpp:32:22: error: ‘bool Coral::Attribute::GetFieldValue(std::string_view)’ cannot be overloaded with ‘std::string Coral::Attribute::GetFieldValue(std::string_view)’
   32 |                 bool GetFieldValue(std::string_view InFieldName)
      |                      ^~~~~~~~~~~~~
Include/Coral/Attribute.hpp:24:29: note: previous declaration ‘std::string Coral::Attribute::GetFieldValue(std::string_view)’
   24 |                 std::string GetFieldValue(std::string_view InFieldName)
      |                             ^~~~~~~~~~~~~
In file included from Source/Coral/ManagedObject.cpp:1:
Include/Coral/ManagedObject.hpp:61:26: error: explicit specialization in non-namespace scope ‘class Coral::ManagedObject’
   61 |                 template<>
      |                          ^
Include/Coral/ManagedObject.hpp:69:26: error: explicit specialization in non-namespace scope ‘class Coral::ManagedObject’
   69 |                 template<>
      |                          ^
Include/Coral/ManagedObject.hpp:84:26: error: explicit specialization in non-namespace scope ‘class Coral::ManagedObject’
   84 |                 template<>
      |                          ^
Include/Coral/ManagedObject.hpp:94:26: error: explicit specialization in non-namespace scope ‘class Coral::ManagedObject’
   94 |                 template<>
      |                          ^
Include/Coral/ManagedObject.hpp:95:22: error: ‘bool Coral::ManagedObject::GetFieldValue(std::string_view) const’ cannot be overloaded with ‘std::string Coral::ManagedObject::GetFieldValue(std::string_view) const’
   95 |                 bool GetFieldValue(std::string_view InFieldName) const
      |                      ^~~~~~~~~~~~~
Include/Coral/ManagedObject.hpp:85:29: note: previous declaration ‘std::string Coral::ManagedObject::GetFieldValue(std::string_view) const’
   85 |                 std::string GetFieldValue(std::string_view InFieldName) const
      |                             ^~~~~~~~~~~~~
In file included from Source/Coral/Attribute.cpp:1:
Include/Coral/Attribute.hpp:23:26: error: explicit specialization in non-namespace scope ‘class Coral::Attribute’
   23 |                 template<>
      |                          ^
Include/Coral/Attribute.hpp:31:26: error: explicit specialization in non-namespace scope ‘class Coral::Attribute’
   31 |                 template<>
      |                          ^
Include/Coral/Attribute.hpp:32:22: error: ‘bool Coral::Attribute::GetFieldValue(std::string_view)’ cannot be overloaded with ‘std::string Coral::Attribute::GetFieldValue(std::string_view)’
   32 |                 bool GetFieldValue(std::string_view InFieldName)
      |                      ^~~~~~~~~~~~~
Include/Coral/Attribute.hpp:24:29: note: previous declaration ‘std::string Coral::Attribute::GetFieldValue(std::string_view)’
   24 |                 std::string GetFieldValue(std::string_view InFieldName)
      |                             ^~~~~~~~~~~~~
In file included from Include/Coral/Type.hpp:5,
                 from Source/Coral/PropertyInfo.cpp:2:
Include/Coral/ManagedObject.hpp:61:26: error: explicit specialization in non-namespace scope ‘class Coral::ManagedObject’
   61 |                 template<>
      |                          ^
Include/Coral/ManagedObject.hpp:69:26: error: explicit specialization in non-namespace scope ‘class Coral::ManagedObject’
   69 |                 template<>
      |                          ^
Include/Coral/ManagedObject.hpp:84:26: error: explicit specialization in non-namespace scope ‘class Coral::ManagedObject’
   84 |                 template<>
      |                          ^
Include/Coral/ManagedObject.hpp:94:26: error: explicit specialization in non-namespace scope ‘class Coral::ManagedObject’
   94 |                 template<>
      |                          ^
Include/Coral/ManagedObject.hpp:95:22: error: ‘bool Coral::ManagedObject::GetFieldValue(std::string_view) const’ cannot be overloaded with ‘std::string Coral::ManagedObject::GetFieldValue(std::string_view) const’
   95 |                 bool GetFieldValue(std::string_view InFieldName) const
      |                      ^~~~~~~~~~~~~
Include/Coral/ManagedObject.hpp:85:29: note: previous declaration ‘std::string Coral::ManagedObject::GetFieldValue(std::string_view) const’
   85 |                 std::string GetFieldValue(std::string_view InFieldName) const
      |                             ^~~~~~~~~~~~~
In file included from Include/Coral/Type.hpp:5,
                 from Source/Coral/Attribute.cpp:2:
Include/Coral/ManagedObject.hpp:61:26: error: explicit specialization in non-namespace scope ‘class Coral::ManagedObject’
   61 |                 template<>
      |                          ^
Include/Coral/ManagedObject.hpp:69:26: error: explicit specialization in non-namespace scope ‘class Coral::ManagedObject’
   69 |                 template<>
      |                          ^
Include/Coral/ManagedObject.hpp:84:26: error: explicit specialization in non-namespace scope ‘class Coral::ManagedObject’
   84 |                 template<>
      |                          ^
Include/Coral/ManagedObject.hpp:94:26: error: explicit specialization in non-namespace scope ‘class Coral::ManagedObject’
   94 |                 template<>
      |                          ^
Include/Coral/ManagedObject.hpp:95:22: error: ‘bool Coral::ManagedObject::GetFieldValue(std::string_view) const’ cannot be overloaded with ‘std::string Coral::ManagedObject::GetFieldValue(std::string_view) const’
   95 |                 bool GetFieldValue(std::string_view InFieldName) const
      |                      ^~~~~~~~~~~~~
Include/Coral/ManagedObject.hpp:85:29: note: previous declaration ‘std::string Coral::ManagedObject::GetFieldValue(std::string_view) const’
   85 |                 std::string GetFieldValue(std::string_view InFieldName) const
      |                             ^~~~~~~~~~~~~
In file included from Include/Coral/Type.hpp:5,
                 from Include/Coral/Assembly.hpp:3,
                 from Source/Coral/Assembly.cpp:1:
Include/Coral/ManagedObject.hpp:61:26: error: explicit specialization in non-namespace scope ‘class Coral::ManagedObject’
   61 |                 template<>
      |                          ^
Include/Coral/ManagedObject.hpp:69:26: error: explicit specialization in non-namespace scope ‘class Coral::ManagedObject’
   69 |                 template<>
      |                          ^
Include/Coral/ManagedObject.hpp:84:26: error: explicit specialization in non-namespace scope ‘class Coral::ManagedObject’
   84 |                 template<>
      |                          ^
Include/Coral/ManagedObject.hpp:94:26: error: explicit specialization in non-namespace scope ‘class Coral::ManagedObject’
   94 |                 template<>
      |                          ^
Include/Coral/ManagedObject.hpp:95:22: error: ‘bool Coral::ManagedObject::GetFieldValue(std::string_view) const’ cannot be overloaded with ‘std::string Coral::ManagedObject::GetFieldValue(std::string_view) const’
   95 |                 bool GetFieldValue(std::string_view InFieldName) const
      |                      ^~~~~~~~~~~~~
Include/Coral/ManagedObject.hpp:85:29: note: previous declaration ‘std::string Coral::ManagedObject::GetFieldValue(std::string_view) const’
   85 |                 std::string GetFieldValue(std::string_view InFieldName) const
      |                             ^~~~~~~~~~~~~
In file included from Source/Coral/PropertyInfo.cpp:3:
Include/Coral/Attribute.hpp:23:26: error: explicit specialization in non-namespace scope ‘class Coral::Attribute’
   23 |                 template<>
      |                          ^
Include/Coral/Attribute.hpp:31:26: error: explicit specialization in non-namespace scope ‘class Coral::Attribute’
   31 |                 template<>
      |                          ^
Include/Coral/Attribute.hpp:32:22: error: ‘bool Coral::Attribute::GetFieldValue(std::string_view)’ cannot be overloaded with ‘std::string Coral::Attribute::GetFieldValue(std::string_view)’
   32 |                 bool GetFieldValue(std::string_view InFieldName)
      |                      ^~~~~~~~~~~~~
Include/Coral/Attribute.hpp:24:29: note: previous declaration ‘std::string Coral::Attribute::GetFieldValue(std::string_view)’
   24 |                 std::string GetFieldValue(std::string_view InFieldName)
      |                             ^~~~~~~~~~~~~
make[1]: *** [Makefile:176: ../Intermediates/Debug/Debug/Coral.Native/FieldInfo.o] Error 1
make[1]: *** Waiting for unfinished jobs....
make[1]: *** [Makefile:173: ../Intermediates/Debug/Debug/Coral.Native/Attribute.o] Error 1
make[1]: *** [Makefile:185: ../Intermediates/Debug/Debug/Coral.Native/ManagedObject.o] Error 1
make[1]: *** [Makefile:191: ../Intermediates/Debug/Debug/Coral.Native/MethodInfo.o] Error 1
make[1]: *** [Makefile:194: ../Intermediates/Debug/Debug/Coral.Native/PropertyInfo.o] Error 1
In file included from Include/Coral/Type.hpp:5,
                 from Source/Coral/Type.cpp:1:
Include/Coral/ManagedObject.hpp:61:26: error: explicit specialization in non-namespace scope ‘class Coral::ManagedObject’
   61 |                 template<>
      |                          ^
Include/Coral/ManagedObject.hpp:69:26: error: explicit specialization in non-namespace scope ‘class Coral::ManagedObject’
   69 |                 template<>
      |                          ^
Include/Coral/ManagedObject.hpp:84:26: error: explicit specialization in non-namespace scope ‘class Coral::ManagedObject’
   84 |                 template<>
      |                          ^
Include/Coral/ManagedObject.hpp:94:26: error: explicit specialization in non-namespace scope ‘class Coral::ManagedObject’
   94 |                 template<>
      |                          ^
Include/Coral/ManagedObject.hpp:95:22: error: ‘bool Coral::ManagedObject::GetFieldValue(std::string_view) const’ cannot be overloaded with ‘std::string Coral::ManagedObject::GetFieldValue(std::string_view) const’
   95 |                 bool GetFieldValue(std::string_view InFieldName) const
      |                      ^~~~~~~~~~~~~
Include/Coral/ManagedObject.hpp:85:29: note: previous declaration ‘std::string Coral::ManagedObject::GetFieldValue(std::string_view) const’
   85 |                 std::string GetFieldValue(std::string_view InFieldName) const
      |                             ^~~~~~~~~~~~~
make[1]: *** [Makefile:182: ../Intermediates/Debug/Debug/Coral.Native/HostInstance.o] Error 1
make[1]: *** [Makefile:170: ../Intermediates/Debug/Debug/Coral.Native/Assembly.o] Error 1
In file included from Source/Coral/Type.cpp:4:
Include/Coral/Attribute.hpp:23:26: error: explicit specialization in non-namespace scope ‘class Coral::Attribute’
   23 |                 template<>
      |                          ^
Include/Coral/Attribute.hpp:31:26: error: explicit specialization in non-namespace scope ‘class Coral::Attribute’
   31 |                 template<>
      |                          ^
Include/Coral/Attribute.hpp:32:22: error: ‘bool Coral::Attribute::GetFieldValue(std::string_view)’ cannot be overloaded with ‘std::string Coral::Attribute::GetFieldValue(std::string_view)’
   32 |                 bool GetFieldValue(std::string_view InFieldName)
      |                      ^~~~~~~~~~~~~
Include/Coral/Attribute.hpp:24:29: note: previous declaration ‘std::string Coral::Attribute::GetFieldValue(std::string_view)’
   24 |                 std::string GetFieldValue(std::string_view InFieldName)
      |                             ^~~~~~~~~~~~~
make[1]: *** [Makefile:203: ../Intermediates/Debug/Debug/Coral.Native/Type.o] Error 1
make: *** [Makefile:38: Coral.Native] Error 2
```