### PR TITLE
Neal/fpu guard fix

### DIFF
--- a/Coral.Native/Include/Coral/FPUGuard.hpp
+++ b/Coral.Native/Include/Coral/FPUGuard.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+// Workaround for a CoreCLR bug on x86-64 Windows: when an [UnmanagedCallersOnly]
+// function body completes a catch (Exception) block, the managed->native return
+// transition corrupts caller-saved XMM6-XMM15 (and sometimes MXCSR / x87 state).
+//
+// Measured with RtlCaptureContext at 4 probe points — corruption is isolated to
+// the catch-exit + UCO return stub. All other phases (reflection dispatch,
+// exception propagation, catch body, callbacks out) preserve XMMs correctly.
+//
+// FPUGuard is a zero-cost RAII wrapper around _fxsave/_fxrstor. Drop one at the
+// start of any native scope that calls through a function pointer into managed
+// code that might catch exceptions. Cost is ~100 cycles per save+restore.
+
+#if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(_M_IX86)
+	#include <immintrin.h>
+	#define CORAL_HAS_FXSAVE 1
+#else
+	#define CORAL_HAS_FXSAVE 0
+#endif
+
+namespace Coral {
+
+	struct FPUGuard
+	{
+#if CORAL_HAS_FXSAVE
+		alignas(16) char State[512];
+		FPUGuard()  { _fxsave(State); }
+		~FPUGuard() { _fxrstor(State); }
+#endif
+		FPUGuard(const FPUGuard&) = delete;
+		FPUGuard& operator=(const FPUGuard&) = delete;
+	};
+
+}

--- a/Coral.Native/Include/Coral/FPUGuard.hpp
+++ b/Coral.Native/Include/Coral/FPUGuard.hpp
@@ -12,9 +12,16 @@
 // start of any native scope that calls through a function pointer into managed
 // code that might catch exceptions. Cost is ~100 cycles per save+restore.
 
-#if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(_M_IX86)
+#if defined(__x86_64__) || defined(_M_X64)
 	#include <immintrin.h>
 	#define CORAL_HAS_FXSAVE 1
+	#define CORAL_FXSAVE(p)  _fxsave64(p)
+	#define CORAL_FXRSTOR(p) _fxrstor64(p)
+#elif defined(__i386__) || defined(_M_IX86)
+	#include <immintrin.h>
+	#define CORAL_HAS_FXSAVE 1
+	#define CORAL_FXSAVE(p)  _fxsave(p)
+	#define CORAL_FXRSTOR(p) _fxrstor(p)
 #else
 	#define CORAL_HAS_FXSAVE 0
 #endif
@@ -25,8 +32,8 @@ namespace Coral {
 	{
 #if CORAL_HAS_FXSAVE
 		alignas(16) char State[512];
-		FPUGuard()  { _fxsave(State); }
-		~FPUGuard() { _fxrstor(State); }
+		FPUGuard()  { CORAL_FXSAVE(State); }
+		~FPUGuard() { CORAL_FXRSTOR(State); }
 #endif
 		FPUGuard(const FPUGuard&) = delete;
 		FPUGuard& operator=(const FPUGuard&) = delete;

--- a/Coral.Native/Source/Coral/ManagedObject.cpp
+++ b/Coral.Native/Source/Coral/ManagedObject.cpp
@@ -4,6 +4,7 @@
 #include "Coral/StringHelper.hpp"
 #include "Coral/Type.hpp"
 #include "Coral/TypeCache.hpp"
+#include "Coral/FPUGuard.hpp"
 
 #include "CoralManagedFunctions.hpp"
 
@@ -59,10 +60,10 @@ namespace Coral {
 
 	void ManagedObject::InvokeMethodInternal(std::string_view InMethodName, const void** InParameters, const ManagedType* InParameterTypes, size_t InLength) const
 	{
-		// NOTE(Peter): If you get an exception in this function it's most likely because you're using a Native only debugger type in Visual Studio
-		//				and it's catching a C# exception even though it shouldn't. I recommend switching the debugger type to Mixed (.NET Core)
-		//				which should be the default for Hazelnut, or simply press "Continue" until it works.
-		//				This is a problem with the Visual Studio debugger and nothing we can change.
+		// FPUGuard workaround for CoreCLR bug on x86-64 Windows: when the managed
+		// InvokeMethod body executes a caught exception, the UCO return transition
+		// corrupts caller-saved XMM6-XMM15. See Coral/FPUGuard.hpp.
+		FPUGuard fpu;
 		auto methodName = String::New(InMethodName);
 		s_ManagedFunctions.InvokeMethodFptr(m_Handle, methodName, InParameters, InParameterTypes, static_cast<int32_t>(InLength));
 		String::Free(methodName);
@@ -70,6 +71,7 @@ namespace Coral {
 
 	void ManagedObject::InvokeMethodRetInternal(std::string_view InMethodName, const void** InParameters, const ManagedType* InParameterTypes, size_t InLength, void* InResultStorage) const
 	{
+		FPUGuard fpu;
 		auto methodName = String::New(InMethodName);
 		s_ManagedFunctions.InvokeMethodRetFptr(m_Handle, methodName, InParameters, InParameterTypes, static_cast<int32_t>(InLength), InResultStorage);
 		String::Free(methodName);


### PR DESCRIPTION
Root cause (short)
On x86-64 Windows, CoreCLR corrupts caller-saved XMM6–XMM15 when an [UnmanagedCallersOnly] function returns through the managed→native transition after its body executed a catch (Exception) block. This violates the Win64 ABI. Coral's ManagedObject.InvokeMethod catches every script exception, so the corruption hits on every uncaught throw.

Narrowed with RtlCaptureContext at 4 probe points;
https://github.com/luckyrobots/Coral/tree/neal/fpu-guard-fix

The fix
Native-only workaround in our Coral fork: RAII _fxsave / _fxrstor guard at the top of InvokeMethodInternal and InvokeMethodRetInternal. Saves ~512 bytes of FPU/SSE state on entry, restores on scope exit.

Cost: ~100 CPU cycles per invoke (~0.2 ms/sec at 60 fps × 100 scripts/frame). Unmeasurable.
No managed-side changes, no engine-side changes beyond the submodule bump.
Compiles to no-op on ARM (CORAL_HAS_FXSAVE guard).
Limitations (honest)

Not a root-cause fix. The real bug is in CoreCLR's UCO return stub, this is a workaround at the boundary. Should eventually be fixed in dotnet/runtime, however waiting for a fix on an unknown timeline is not good especially given the impact of this issue.
Doesn't cover StackOverflowException. CoreCLR terminates the process before any userland code can run. No workaround possible without custom .NET hosting.
ARM64 unprotected. Initial macOS testing suggests NEON registers are not affected by this issue but we have not proven it. Safe default: no-op on ARM.